### PR TITLE
Update external.py to match sktime package update

### DIFF
--- a/tsai/data/external.py
+++ b/tsai/data/external.py
@@ -16,7 +16,7 @@ except ImportError: from urllib.request import urlretrieve
 import shutil
 from pyunpack import Archive
 from scipy.io import arff
-from sktime.utils.load_data import load_from_tsfile_to_dataframe
+from sktime.utils.data_io import load_from_tsfile_to_dataframe
 
 # Cell
 def decompress_from_url(url, target_dir=None, verbose=False):


### PR DESCRIPTION
changed : `from sktime.utils.load_data import load_from_tsfile_to_dataframe`
to : `from sktime.utils.data_io import load_from_tsfile_to_dataframe`
Due to error: 

> ModuleNotFoundError: No module named 'sktime.utils.load_data'