### PR TITLE
Removing now redundant --cpu flag from tutorial_nbs 01_Intro

### DIFF
--- a/tutorial_nbs/01_Intro_to_Time_Series_Classification.ipynb
+++ b/tutorial_nbs/01_Intro_to_Time_Series_Classification.ipynb
@@ -917,7 +917,7 @@
     }
    ],
    "source": [
-    "learn = load_learner_all(path='export', dls_fname='dls', model_fname='model', learner_fname='learner', cpu=True)\n",
+    "learn = load_learner_all(path='export', dls_fname='dls', model_fname='model', learner_fname='learner')\n",
     "dls = learn.dls\n",
     "valid_dl = dls.valid\n",
     "b = next(iter(valid_dl))\n",
@@ -1745,7 +1745,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Just running the example notebook and came across this bug.. It seems the `cpu` flag does not exist anymore?
Let me know if you want a test putting in for it.