### PR TITLE
Comment appears backwards from actual code

### DIFF
--- a/tutorial_nbs/10_Time_Series_Classification_and_Regression_with_MiniRocket.ipynb
+++ b/tutorial_nbs/10_Time_Series_Classification_and_Regression_with_MiniRocket.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "# ## NOTE: UNCOMMENT AND RUN THIS CELL IF YOU NEED TO INSTALL/ UPGRADE TSAI\n",
-    "# stable = False # True: latest version from github, False: stable version in pip\n",
+    "# stable = False # False: latest version from github, True: stable version in pip\n",
     "# if stable: \n",
     "#     !pip install tsai -U >> /dev/null\n",
     "# else:      \n",


### PR DESCRIPTION
`if stable` runs pip install, so that leads me to think stable needs to be True in order to install the stable version from pip, not False as the comment indicated.