### PR TITLE
Change num_features to num_kernels.

### DIFF
--- a/tsai/models/MINIROCKET.py
+++ b/tsai/models/MINIROCKET.py
@@ -26,7 +26,7 @@ class MiniRocketClassifier(sklearn.pipeline.Pipeline):
         For a larger dataset, you can use MINIROCKET (in Pytorch).
         scoring = None --> defaults to accuracy.
         """
-        self.steps = [('minirocketmultivariate', MiniRocketMultivariate(num_features=num_features,
+        self.steps = [('minirocketmultivariate', MiniRocketMultivariate(num_kernels=num_features,
                                                                         max_dilations_per_kernel=max_dilations_per_kernel,
                                                                         random_state=random_state)),
                       ('ridgeclassifiercv', RidgeClassifierCV(alphas=alphas,
@@ -66,7 +66,7 @@ class MiniRocketRegressor(sklearn.pipeline.Pipeline):
         For a larger dataset, you can use MINIROCKET (in Pytorch).
         scoring = None --> defaults to r2.
         """
-        self.steps = [('minirocketmultivariate', MiniRocketMultivariate(num_features=num_features,
+        self.steps = [('minirocketmultivariate', MiniRocketMultivariate(num_kernels=num_features,
                                                                         max_dilations_per_kernel=max_dilations_per_kernel,
                                                                         random_state=random_state)),
                       ('ridgecv', RidgeCV(alphas=alphas, normalize=normalize_features, scoring=scoring, **kwargs))]


### PR DESCRIPTION
Sktime's parameter name for num_features has been recently changed to num_kernels([link](https://github.com/alan-turing-institute/sktime/blob/ad4f90b0bf391cea81783440874a796d44ff3615/sktime/transformations/panel/rocket/_minirocket_multivariate.py#L35)). Hence, SkLearn-type APIs for Mini-rocket(MiniRocketClassifer & MiniRocketRegressor) are breaking now in tsai. This commit corrects the same.