### PR TITLE
Minor spelling, grammar and formatting contributions to some tutorial notebooks

### DIFF
--- a/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
+++ b/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
@@ -77,11 +77,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "I normally work with time series data. I made the decision to use numpy arrays to store my data since the can easily handle multiple dimensions, and are really very efficient.\n",
+    "I normally work with time series data. I made the decision to use numpy arrays to store my data since they can easily handle multiple dimensions, and are really very efficient.\n",
     "\n",
     "But sometimes datasets are really big (many GBs) and don't fit in memory. So I started looking around and found something that works very well: [**np.memmap**](https://docs.scipy.org/doc/numpy/reference/generated/numpy.memmap.html). Conceptually they work as arrays on disk, and that's how I often call them.\n",
     "\n",
-    "np.memmap creates a map to numpy array you have previously saved on disk, so that you can efficiently access small segments of those (small or large) files on disk, without reading the entire file into memory. And that's exactly what we need with deep learning, be able to quickly create a batch in memory, without reading the entire file (that is stored on disk). \n",
+    "np.memmap creates a map to numpy arrays you have previously saved on disk, so that you can efficiently access small segments of those (small or large) files on disk, without reading the entire file into memory. And that's exactly what we need with deep learning, be able to quickly create a batch in memory, without reading the entire file (that is stored on disk). \n",
     "\n",
     "The best analogy I've found are image files. You may have a very large dataset on disk (that far exceeds your RAM). In order to create your DL datasets, what you pass are the paths to each individual file, so that you can then load a few images and create a batch on demand.\n",
     "\n",
@@ -183,7 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ok. So let's check the size of these files on memory."
+    "Ok. So let's check the size of these files if they were in memory."
    ]
   },
   {
@@ -218,7 +218,7 @@
    "source": [
     "Remember I only have an 8 GB RAM on this laptop, so I couldn't load these datasets in memory.\n",
     "\n",
-    "☣️ Actually I accidentally loaded the \"X_on_disk.npy\" file, and my laptop crahsed so I had to reboot it!\n",
+    "☣️ Actually I accidentally loaded the \"X_on_disk.npy\" file, and my laptop crashed so I had to reboot it!\n",
     "\n",
     "So let's now load data as arrays on disk (np.memmap). The way to do it is super simple, and very efficient. You just do it as you would with a normal array, but add an mmap_mode.\n",
     "\n",
@@ -229,7 +229,7 @@
     "- ‘w+’\tCreate or overwrite existing file for reading and writing.\n",
     "- ‘c’\tCopy-on-write: assignments affect data in memory, but changes are not saved to disk. The file on disk is read-only.\n",
     "\n",
-    "I normally use mode 'c' since I want to be able to make changes to data in memory (transforms for example), without affecting data on disk (same approach as with image data). This is the same thing you do with image files on disk, that are just read, and then modified in memory, without change the file on disk.\n",
+    "I normally use mode 'c' since I want to be able to make changes to data in memory (transforms for example), without affecting data on disk (same approach as with image data). This is the same thing you do with image files on disk, that are just read, and then modified in memory, without changing the file on disk.\n",
     "\n",
     "But if you also want to be able to modify data on disk, you can load the array with mmap_mode='r+'."
    ]
@@ -309,7 +309,7 @@
    "source": [
     "**152 bytes of RAM for a 10GB array**. This is the great benefit of arrays on disk.\n",
     "\n",
-    "Arrays on disk barely use any RAM until each the it's sliced and an element is converted into a np.array or a tensor.\n",
+    "Arrays on disk barely use any RAM until they are accessed or sliced and an element is converted into a np.array or a tensor.\n",
     "\n",
     "This is equivalent to the size of file paths in images (very limited) compared to the files themselves (actual images). "
    ]
@@ -387,7 +387,7 @@
     "- scaling (using normalize or standardize)\n",
     "- transformation into a tensor\n",
     "\n",
-    "Once you get the array on disk slice, you'll convert it into a tensor, move to a GPU and performs operations there."
+    "Once you get the slice from the array on disk, you'll convert it into a tensor, move to a GPU and performs operations there."
    ]
   },
   {
@@ -397,7 +397,7 @@
     "\n",
     "⚠️ You need to be careful though not to convert the entire np.memmap to an array/ tensor if it's larger than your RAM. This will crash your computer unless you have enough RAM, so you would have to reboot!\n",
     "\n",
-    "**DON'T DO THIS:  torch.from_numpy(X) or np.array(X)** unless you have ehough RAM.\n",
+    "**DON'T DO THIS:  torch.from_numpy(X) or np.array(X)** unless you have enough RAM.\n",
     "\n",
     "To avoid issues during test, I created a smaller array on disk (that I can store in memory). When I want to test something I test it with that array first. It's important to always verify that the type output of your operations is np.memmap, which means data is still in memory."
    ]
@@ -413,7 +413,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To ensure you don't brind the entire array in memory (which may crash your computer) you can always work with slices of data, which is by the way how fastai works.\n",
+    "To ensure you don't bring the entire array in memory (which may crash your computer) you can always work with slices of data, which is by the way how fastai works.\n",
     "\n",
     "If you use mode 'r' you can grab a sample and make changes to it, but this won't modify data on disk."
    ]
@@ -455,7 +455,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's important to note that **when we perform an math operation on a np.memmap (add, subtract, ...) the output is a np.array, and no longer a np.memmap.**\n",
+    "It's important to note that **when we perform a math operation on a np.memmap (add, subtract, ...) the output is a np.array, and no longer a np.memmap.**\n",
     "\n",
     "⚠️ Remember you don't want to run this type of operations with a memmap larger than your RAM!! That's why I do it with a slice."
    ]
@@ -1045,7 +1045,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is approx. 10 slower than having arrays on disk, although it's still pretty fast.\n",
+    "This is approximately 10 times slower than having arrays on disk, although it's still pretty fast.\n",
     "\n",
     "However, if we use the itemified version, it's much faster:"
    ]
@@ -1208,7 +1208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So it takes the same time to convert from numpy.memmap or from a np.array in memory is the same."
+    "So it takes the same time to convert from numpy.memmap or from a np.array in memory."
    ]
   },
   {
@@ -1356,8 +1356,20 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/tutorial_nbs/00b_How_to_use_numpy_arrays_in_fastai.ipynb
+++ b/tutorial_nbs/00b_How_to_use_numpy_arrays_in_fastai.ipynb
@@ -27,23 +27,22 @@
    "source": [
     "I'd like to share with you how you can work with numpy arrays in **fastai** through a time series classification example. \n",
     "\n",
-    "I've used timeseriesAI (based on v1 extensiively). To be able to use fastai v2 I have a few requirements: \n",
-    "\n",
+    "I've used timeseriesAI (based on v1 extensively). To be able to use fastai v2 I have a few requirements: \n",
     "\n",
     "* Use univariate and multivariate time series\n",
-    "* Use labeled (X,y) and unlabeled (X,) datasets\n",
-    "* Data may be already split in train/ valid\n",
+    "* Use labelled (X,y) and unlabelled (X,) datasets\n",
+    "* Data may be already split in train/valid\n",
     "* In-memory and on-disk np.arrays (np.memmap in case of larger than RAM data)\n",
     "* Slice the dataset (based on selected variables and/ or sequence steps)\n",
-    "* Use item and batch tfms\n",
+    "* Use item and batch tfms (transforms)\n",
     "* Create batch with specified output types (TSTensor, TensorCategory, etc)\n",
     "* Show batch (with tfms)\n",
     "* Show results\n",
-    "* Add test data and unlabeled datasets\n",
+    "* Add test data and unlabelled datasets\n",
     "* Export and predict on new data\n",
     "* Equal or better performance than native Pytorch, fastai v1 & vanilla fastai v2\n",
     "\n",
-    "These are pretty challanging. Let's see if fastai can meet them (with limited customization)."
+    "These are pretty challenging. Let's see if fastai can meet them (with limited customization)."
    ]
   },
   {
@@ -143,9 +142,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -209,7 +206,7 @@
    "source": [
     "Since fastai is based on Pytorch, you'll need to somehow transform the numpy arrays to tensors (NumpyTensor or TSTensor for TS). \n",
     "\n",
-    "There're transform functions called ToNumpyTensor/ ToTSTensor that transforms an array into a tensor of type NumpyTensor/ TSTensor (both have a show method)."
+    "There are transform functions called ToNumpyTensor/ ToTSTensor that transform an array into a tensor of type NumpyTensor/ TSTensor (both have a show method)."
    ]
   },
   {
@@ -285,7 +282,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In fastai v2 there are multiple options to create dataloaders. Let's see some of them and most importantly wheteher they meet our requirements.\n",
+    "In fastai v2 there are multiple options to create dataloaders. Let's see some of them and most importantly whether they meet our requirements.\n",
     "\n",
     "I will compare performance on 2 processes: \n",
     "\n",
@@ -491,7 +488,7 @@
    "source": [
     "This is very fast, but:\n",
     "\n",
-    "* batch is returned on **cpu** (so additional time is required to pass it to gpu). The challanging benchmark is the one in the cycle_dl_to_device(valid_dl) test.\n",
+    "* batch is returned on **cpu** (so additional time is required to pass it to the gpu). The challenging benchmark is the one in the cycle_dl_to_device(valid_dl) test.\n",
     "* cannot be easily integrated with fastai.\n",
     "\n",
     "It will be difficult to find a solution that performs at the same level 😅!"
@@ -584,9 +581,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But this is relatively slow, as DataLoader processes samples one at a time, and each item needs to be casted to the appropriate type.\n",
+    "But this is relatively slow, as DataLoader processes samples one at a time, and each item needs to be cast to the appropriate type.\n",
     "\n",
-    "Note: we'll see how this can accelerated later by processing all batch samples at once."
+    "Note: we'll see how this can be accelerated later by processing all batch samples at once."
    ]
   },
   {
@@ -1415,7 +1412,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So it takes > 3 s to cycle the entire dataloader. This is much slower than Pytorch simple model (although fastai v2 provides a lot more functionality!)."
+    "So it takes more than 3 seconds to cycle the entire dataloader. This is much slower than Pytorch simple model (although fastai v2 provides a lot more functionality!)."
    ]
   },
   {
@@ -2094,9 +2091,9 @@
    "source": [
     "So far we we've seen fastai v2 is very flexible and easy to use, but it's slow compared to v1 (in this example the Datablock API was 65% slower). \n",
     "\n",
-    "There are at least 3 major differences between vision and time series - TS- (and numpy based data in general) that we can leverage to improve performance: \n",
+    "There are at least 3 major differences between vision and time series -TS- (and numpy based data in general) that we can leverage to improve performance: \n",
     "\n",
-    "1. Vision tipically requires some item preprocessing that is sometimes random. For example, when you randomly crop an image. Each time it'll return a different value. However, with time series, most item transforms are **deterministic** (actually most impact the label only).\n",
+    "1. Vision typically requires some item preprocessing that is sometimes random. For example, when you randomly crop an image. Each time it'll return a different value. However, with time series, most item transforms are **deterministic** (actually most impact the label only).\n",
     "\n",
     "2. In vision problems, you usually derive the image and label from a single item (path). In TS problems, it's common to have data already **split between X and y**. It doesn't make much sense to have data already split (into X and y) to merge them in a single item and process them together. \n",
     "\n",
@@ -2124,10 +2121,9 @@
     "* you are **not using any tfms, or**\n",
     "* if you are using tfms, **transformed X (and y) both fit in memory**\n",
     "\n",
-    "In any inplace won't be effective for items of type np.memmap (to avoid trying to load in memory larger that RAM datasets).\n",
-    "In many time series problems, X transforms can be applied after a batch has been created. In all this cases, you can use inplace=True.\n",
+    "Using `inplace` won't be effective for items of type np.memmap (to avoid trying to load in memory larger that RAM datasets). In many time series problems, X transforms can be applied after a batch has been created. In all these cases, you can use inplace=True.\n",
     "\n",
-    "Inplace=true only impact item transforms."
+    "`inplace=true` only impact item transforms."
    ]
   },
   {
@@ -2342,7 +2338,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's see how does this compare to NumpyDatasets when tfms are not preprocessed:"
+    "Let's see how this compares to NumpyDatasets when tfms are not preprocessed:"
    ]
   },
   {
@@ -2499,7 +2495,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's see how is performance when data is preprocessed:"
+    "Let's see how the performance when data is preprocessed:"
    ]
   },
   {
@@ -3665,9 +3661,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -4052,9 +4046,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -4110,9 +4102,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -4223,9 +4213,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -4259,9 +4247,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -4291,7 +4277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Add additional labeled test data"
+    "### Add additional labelled test data"
    ]
   },
   {
@@ -4317,7 +4303,7 @@
     }
    ],
    "source": [
-    "# Labeled test data\n",
+    "# labelled test data\n",
     "test_ds = dls.valid.dataset.add_test(X, y)\n",
     "test_dl = dls.valid.new(test_ds)\n",
     "next(iter(test_dl))"
@@ -4354,9 +4340,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -4420,7 +4404,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Add additional unlabeled test data"
+    "### Add additional unlabelled test data"
    ]
   },
   {
@@ -4440,7 +4424,7 @@
     }
    ],
    "source": [
-    "# Unlabeled test data\n",
+    "# Unlabelled test data\n",
     "test_ds = dls.dataset.add_test(X)\n",
     "test_dl = dls.valid.new(test_ds)\n",
     "next(iter(test_dl))"
@@ -4477,9 +4461,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -4526,8 +4508,8 @@
     "\n",
     "* We can easily use numpy arrays (or anything that can be converted into np arrays). For example, this can be used for **univariate and multivariate time series**.\n",
     "* Easy to use scikit-learn type of API (X, (y))\n",
-    "* We can use both **labeled and unlabeled datasets**\n",
-    "* We can also use **larger than RAM datasets**, keeping data on disk (using np.memmap -see nb 00 for more details-).\n",
+    "* We can use both **labelled and unlabelled datasets**\n",
+    "* We can also use **larger than RAM datasets**, keeping data on disk (using np.memmap -see [notebook 00](00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb) for more details-).\n",
     "* Use item and batch tfms\n",
     "* Show batch method after tfms have been applied\n",
     "* Show results after training\n",
@@ -4535,6 +4517,13 @@
     "* With NumpyDatasets + NumpyDataLoaders batch creation is **25+x faster than fastai v1** and **100+ times faster than vanilla fastai v2** (for numpy arrays).\n",
     "* This results in **2.5-3x faster training** than fastai v1 and **4-5x faster than vanilla fastai v2** (for numpy arrays)."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -4542,8 +4531,20 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/tutorial_nbs/00c_Time_Series_data_preparation.ipynb
+++ b/tutorial_nbs/00c_Time_Series_data_preparation.ipynb
@@ -2894,9 +2894,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a example using real data where the dataframe already the data split by sample. Let's first simulate how you could get the pandas df.\n",
+    "This is a example using real data where the dataframe already has the data split by sample. Let's first simulate how you could get the pandas df.\n",
     "\n",
-    "In this case, you only need to convert the df format to X and y using `df2xy`as we have seen before."
+    "In this case, you only need to convert the dataframe format to X and y using `df2xy`as we have seen before."
    ]
   },
   {
@@ -3817,8 +3817,20 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/tutorial_nbs/01_Intro_to_Time_Series_Classification.ipynb
+++ b/tutorial_nbs/01_Intro_to_Time_Series_Classification.ipynb
@@ -151,7 +151,7 @@
    "source": [
     "In the case of UCR data it's very easy to get data loaded. Let's select a dataset. You can modify this and select any one from the previous lists (univariate of multivariate).\n",
     "\n",
-    "return_split determines whether UCR data will be returned already split between train and test or not."
+    "`return_split` determines whether the UCR data will be returned already split between train and test or not."
    ]
   },
   {
@@ -252,7 +252,7 @@
     "\n",
     "In TS classification problems, you will usually want to use an item tfm to transform y into categories.\n",
     "\n",
-    "We'll use inplace=True to preprocess data at dataset initialization. This will significantly speed up training. "
+    "We'll use `inplace=True` to preprocess data at dataset initialization. This will significantly speed up training. "
    ]
   },
   {
@@ -269,12 +269,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll now build the dataloaders that will create batches of data.\n",
+    "We'll now build the `DataLoader`s (dls) that will create batches of data.\n",
     "\n",
     "You will need to pass:\n",
     "\n",
-    "* datasets: usually 2 - train and valid -  or 1 - test or unlabeled- depending on the problem\n",
-    "* batch size(s): you may pass a single value (will will be appied to all dls, or different values, one for each dl.\n",
+    "* datasets: usually 2 - train and valid -  or 1 - test or unlabelled- depending on the problem\n",
+    "* batch size(s): you may pass a single value (will be applied to all dls, or different values, one for each dl.\n",
     "* batch_tfms (same as after_batch): you may decide to pass some tfms at the batch level. In this case for example, we'll standardize the data (0 mean and 1 std). You may get more details on how these transforms work in the transforms nb.\n",
     "* num workers: num_workers > 0 is used to preprocess batches of data so that the next batch is ready for use when the current batch has been finished. More num_workers would consume more memory usage but is helpful to speed up the I/O process. This will depend on your machine, dataset, etc. You may want to start with 0, and test other values to see how to train faster. For me, 0 works better."
    ]
@@ -952,7 +952,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We may have additional data (test set) where we want to check our performance. In this case, we'd add a labeled dataset:"
+    "We may have additional data (test set) where we want to check our performance. In this case, we'd add a labelled dataset:"
    ]
   },
   {
@@ -978,7 +978,7 @@
     }
    ],
    "source": [
-    "# Labeled test data\n",
+    "# Labelled test data\n",
     "test_ds = valid_dl.dataset.add_test(X, y)# In this case I'll use X and y, but this would be your test data\n",
     "test_dl = valid_dl.new(test_ds)\n",
     "next(iter(test_dl))"
@@ -1079,7 +1079,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If data is unlabeled, we'd just do this: "
+    "If data is unlabelled, we'd just do this: "
    ]
   },
   {
@@ -1099,7 +1099,7 @@
     }
    ],
    "source": [
-    "# Unlabeled data\n",
+    "# Unlabelled data\n",
     "test_ds = dls.dataset.add_test(X)\n",
     "test_dl = valid_dl.new(test_ds)\n",
     "next(iter(test_dl))"
@@ -1634,8 +1634,20 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/tutorial_nbs/01a_MultiClass_MultiLabel_TSClassification.ipynb
+++ b/tutorial_nbs/01a_MultiClass_MultiLabel_TSClassification.ipynb
@@ -29,16 +29,16 @@
    "source": [
     "The purpose of this notebook is to demonstrate both multi-class and multi-label classification using `tsai`. \n",
     "\n",
-    "- Multi-class classification: While the output can take on multiple possible values, for any given sample the output can take on only a single value. In other words, the label values are mutually exclusive. Implication:\n",
-    " - CategoricalCrossEntropy (`nn.CrossEntropyLoss` in Pytorch, `CrossEntropyLossFlat` in fastai) is used as the loss function during training\n",
-    " - Softmax is used to determine prediction since only one label value can be true, the predicted label is the value label value with the greatest probability. \n",
-    " - Softmax reduces the potential for spurious label predictions since only the label with the highest probability is selected\n",
-    " - In both Pytorch and fastai the loss combines a Softmax layer and the CrossEntropyLoss in one single class, so Softmax shouldn't be added to the model.\n",
+    "- Multi-class classification: While the output can take on multiple possible values, for any given sample the output can take on only a single value. In other words, the label values are mutually exclusive. Implication are:\n",
+    "  - CategoricalCrossEntropy (`nn.CrossEntropyLoss` in Pytorch, `CrossEntropyLossFlat` in fastai) is used as the loss function during training\n",
+    "  - Softmax is used to determine prediction since only one label value can be true, the predicted label is the value label value with the greatest probability. \n",
+    "  - Softmax reduces the potential for spurious label predictions since only the label with the highest probability is selected\n",
+    "  - In both Pytorch and fastai the loss combines a Softmax layer and the CrossEntropyLoss in one single class, so Softmax shouldn't be added to the model.\n",
     " \n",
-    "- Multi-label classification: This is the more general case where an individual sample can have one or more labels, relaxing the mutual label exclusivity constraint. Implications:\n",
-    " - BinaryCrossEntropy (`nn.BCEWithLogitsLoss` in Pytorch, `BCEWithLogitsLossFlat` in fastai) is used as the loss function during training\n",
-    " - Sigmoid is used to determine prediction since multiple labels may be true. In both Pytorch and fastai the loss combines a Sigmoid layer and the BCELoss in one single class, so Sigmoid shouldn't be added to the model.\n",
-    " - Relative to multi-class classification, multi-label classification may be more prone to spurious false-positive labels."
+    "- Multi-label classification: This is the more general case where an individual sample can have one or more labels, relaxing the mutual label exclusivity constraint. Implications are:\n",
+    "  - BinaryCrossEntropy (`nn.BCEWithLogitsLoss` in Pytorch, `BCEWithLogitsLossFlat` in fastai) is used as the loss function during training\n",
+    "  - Sigmoid is used to determine prediction since multiple labels may be true. In both Pytorch and fastai the loss combines a Sigmoid layer and the BCELoss in one single class, so Sigmoid shouldn't be added to the model.\n",
+    "  - Relative to multi-class classification, multi-label classification may be more prone to spurious false-positive labels."
    ]
   },
   {
@@ -1095,7 +1095,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A naive classifier that always predicts no true labels would achieve 76% accuracy, so the classifier should do much better.  This also demonstrates the weakness of relying overly on the accuracy metric (with by_sample=False) since due to the prevalance of false outputs."
+    "A naive classifier that always predicts no true labels would achieve 76% accuracy, so the classifier should do much better.  This also demonstrates the weakness of relying overly on the accuracy metric (with by_sample=False), due to the prevalance of false outputs."
    ]
   },
   {
@@ -2210,8 +2210,20 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/tutorial_nbs/02_ROCKET_a_new_SOTA_classifier.ipynb
+++ b/tutorial_nbs/02_ROCKET_a_new_SOTA_classifier.ipynb
@@ -1236,7 +1236,7 @@
     "\n",
     "So this is all the code you need to train a state-of-the-art model using rocket and GPU in `tsai`:\n",
     "\n",
-    "```\n",
+    "```python\n",
     "X, y, splits = get_UCR_data('HandMovementDirection', return_split=False)\n",
     "tfms  = [None, [Categorize()]]\n",
     "batch_tfms = [TSStandardize(by_sample=True)]\n",
@@ -1250,6 +1250,13 @@
     "print(f'alpha: {ridge.alpha_:.2E}  train: {ridge.score(X_train, y_train):.5f}  valid: {ridge.score(X_valid, y_valid):.5f}')\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1257,8 +1264,20 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
As I was going through the first tutorial notebooks I noticed a few minor spelling / grammar contributions I could make. I have only touched the markdown cells, not the executable code cells. 

`jupyter-lab` has added behind my back a `"language_info":` section, which  I hope is of no consequence for any other editor.