### PR TITLE
Cversek patch 1 fix missing bytes2 gb

### DIFF
--- a/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
+++ b/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
@@ -299,8 +299,8 @@
     }
    ],
    "source": [
-    "print(f'X array on disk: {sys.getsizeof(X_on_disk):12} bytes ({bytes2GB(sys.getsizeof(X_on_disk)):3.3f} GB)')\n",
-    "print(f'y array on disk: {sys.getsizeof(y_on_disk):12} bytes ({bytes2GB(sys.getsizeof(y_on_disk)):3.3f} GB)')"
+    "print(f'X array on disk: {sys.getsizeof(X_on_disk):12} bytes ({bytes2str(sys.getsizeof(X_on_disk))})')\n",
+    "print(f'y array on disk: {sys.getsizeof(y_on_disk):12} bytes ({bytes2str(sys.getsizeof(y_on_disk))})')"
    ]
   },
   {

--- a/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
+++ b/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
@@ -1225,7 +1225,7 @@
     "Let's now check performance of the combined process: slicing plus conversion to a tensor. Based on what we've seen there are 3 options: \n",
     "\n",
     "- slice np.array in memory + conversion to tensor\n",
-    "- slice np.memamap on disk + conversion to tensor\n",
+    "- slice np.memmap on disk + conversion to tensor\n",
     "- slice itemified np.memmap + converion to tensor"
    ]
   },

--- a/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
+++ b/tutorial_nbs/00_How_to_efficiently_work_with_very_large_numpy_arrays.ipynb
@@ -201,8 +201,8 @@
     }
    ],
    "source": [
-    "print(f'X array: {os.path.getsize(\"./data/X_on_disk.npy\"):12} bytes ({bytes2GB(os.path.getsize(\"./data/X_on_disk.npy\")):3.2f} GB)')\n",
-    "print(f'y array: {os.path.getsize(\"./data/y_on_disk.npy\"):12} bytes ({bytes2GB(os.path.getsize(\"./data/y_on_disk.npy\")):3.2f} GB)')"
+    "print(f'X array: {os.path.getsize(\"./data/X_on_disk.npy\"):12} bytes ({bytes2str(os.path.getsize(\"./data/X_on_disk.npy\"))})')\n",
+    "print(f'y array: {os.path.getsize(\"./data/y_on_disk.npy\"):12} bytes ({bytes2str(os.path.getsize(\"./data/y_on_disk.npy\"))})')\n"
    ]
   },
   {


### PR DESCRIPTION
Just some simple fixes to the tutorial_nb 00.  FIXES "NameError: name 'bytes2GB' is not defined"