### PR TITLE
Fix TSNormalize to handle cases where max == min by setting output to the lower bound of the target range

### DIFF
--- a/tsai/data/preprocessing.py
+++ b/tsai/data/preprocessing.py
@@ -292,7 +292,11 @@ class TSNormalize(Transform):
             else:
                 _min, _max = o.mul_min(self.axes, keepdim=self.axes!=()), o.mul_max(self.axes, keepdim=self.axes!=())
             self.min, self.max = _min, _max
-        output = ((o - self.min) / (self.max - self.min)) * (self.range_max - self.range_min) + self.range_min
+        diff = self.max - self.min
+        if (diff == 0).any():
+            output = torch.full_like(o, self.range_min) 
+        else:
+            output = ((o - self.min) / diff) * (self.range_max - self.range_min) + self.range_min
         if self.clip_values:
             if self.by_var and is_listy(self.by_var):
                 for v in self.by_var:


### PR DESCRIPTION
This Pull Request addresses an edge case in the `TSNormalize` transform where `max == min` in the input data, which would otherwise result in a division-by-zero error during normalization. 
Instead of returning `None`, the transform now handles this scenario gracefully by setting the output to the lower bound of the target range (`range_min`).