### PR TITLE
Deprecated offset value in pd.date_range() for pandas 3.x

### DIFF
--- a/tsai/data/external.py
+++ b/tsai/data/external.py
@@ -2445,7 +2445,7 @@ def get_forecasting_time_series(
 
         if 'sunspot' in dsid.lower(): # accepts sunspot, Sunspot, sunspots, Sunspots etc.
             df = pd.read_csv(full_tgt_dir)
-            dates = pd.date_range(start=df["Month"].min(), end=pd.to_datetime(df["Month"].max()) + pd.Timedelta(days=30), freq='1M')
+            dates = pd.date_range(start=df["Month"].min(), end=pd.to_datetime(df["Month"].max()) + pd.Timedelta(days=30), freq='MS')
             df["Month"] = dates
             df.set_index('Month', inplace=True)
             return df


### PR DESCRIPTION
There is runtime error in Forecasting Example on the page [here](https://timeseriesai.github.io/tsai/index.html#forecasting) from deprecated offset value in pandas 3.x.

Here's the error:
```
Invalid frequency: 1M. Failed to parse with error message: ValueError("'M' is no longer supported for offsets. Please use 'ME' instead.")
```

The latest offsets list.
[https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases](https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases)
