### PR TITLE
fix: include tsai.* subpackages in built artifacts (#962)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ nb2py = "tsai.export:nb2py"
 version = {attr = "tsai.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["tsai"]
+include = ["tsai", "tsai.*"]
 
 [tool.nbdev]
 tst_flags = 'local slow extras onnx'


### PR DESCRIPTION
## Summary

- Fixes #962: the 1.0.0 PyPI wheel and sdist ship only top-level `tsai/*.py` files; subpackages (`tsai.data`, `tsai.models`, `tsai.callback`, `tsai.inference`, `tsai.optimizer`, etc.) are missing, so a fresh `pip install tsai==1.0.0 && python -c "from tsai.all import *"` fails with `ModuleNotFoundError: No module named 'tsai.data'`.
- Root cause: `[tool.setuptools.packages.find]` had `include = ["tsai"]`. That pattern is an fnmatch glob over fully-qualified package names — `"tsai"` matches only the top-level package; subpackages need `"tsai.*"` too.
- Fix: change `include = ["tsai"]` → `include = ["tsai", "tsai.*"]`, the canonical setuptools pattern.

Verified locally with `python -m build`: the wheel and sdist now bundle 77+ previously missing entries under `tsai/{data,models,callback,inference,optimizer,...}/`.

## Test plan

- [x] `python -m build` succeeds
- [x] `unzip -l dist/tsai-*.whl` shows `tsai/data/`, `tsai/models/`, `tsai/callback/`, etc.
- [x] `tar -tzf dist/tsai-*.tar.gz` shows the same subpackages in the sdist
- [ ] After merge: smoke-test the published artifact (`pip install tsai==<next> && python -c "from tsai.all import *"`) from PyPI before cutting the 1.0.1 announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)