### PR TITLE
ci: verify built wheel ships all subpackages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,3 +9,45 @@ jobs:
         uses: fastai/workflows/nbdev3-ci@master
         with:
           version: "3.11"
+
+  verify-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+      - name: Build wheel and sdist
+        run: python -m build
+      - name: Install built wheel in a clean venv (no deps)
+        run: |
+          python -m venv /tmp/verify
+          /tmp/verify/bin/pip install --no-deps dist/*.whl
+      - name: Verify subpackages and core modules are present in the artifact
+        # `cd /tmp` so the source-tree `tsai/` directory doesn't shadow the
+        # installed wheel via cwd-on-sys.path — that would mask a missing
+        # subpackage in the artifact.
+        working-directory: /tmp
+        run: |
+          /tmp/verify/bin/python - <<'PY'
+          import importlib, importlib.util, sys
+
+          # Subpackages — empty __init__.py files, safe to import directly.
+          # These are the ones the 1.0.0 wheel was missing (#962).
+          import tsai
+          import tsai.data
+          import tsai.models
+          import tsai.callback
+
+          # Top-level modules pull in heavy third-party deps at import time,
+          # so just check they exist in the installed artifact.
+          missing = [m for m in ("tsai.all", "tsai.basics", "tsai.inference",
+                                  "tsai.optimizer", "tsai.tslearner")
+                       if importlib.util.find_spec(m) is None]
+          if missing:
+              sys.exit(f"missing from built wheel: {missing}")
+
+          print(f"tsai {tsai.__version__}: all subpackages and core modules present")
+          PY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ nb2py = "tsai.export:nb2py"
 version = {attr = "tsai.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["tsai"]
+include = ["tsai", "tsai.*"]
 
 [tool.nbdev]
 tst_flags = 'local slow extras onnx'


### PR DESCRIPTION
## Summary

Follow-up to #963. Adds a `verify-build` CI job that catches the class of packaging bug behind #962 (subpackages missing from the built wheel) before it can reach PyPI.

The job:
1. Builds the wheel + sdist with `python -m build`.
2. Installs the wheel into a clean venv with `--no-deps` (fast — no torch download).
3. Imports `tsai.data`, `tsai.models`, `tsai.callback` directly (their `__init__.py` files are empty, so the import is a pure presence check).
4. Uses `importlib.util.find_spec` to confirm the heavy top-level modules (`tsai.all`, `tsai.basics`, `tsai.inference`, `tsai.optimizer`, `tsai.tslearner`) are present, without executing them.

The smoke step runs from `/tmp` so the source-tree `tsai/` directory can't shadow the installed wheel via cwd-on-sys.path — an early local version of this check silently passed on a broken build for exactly that reason.

## Validation

Both directions exercised locally:

- **Buggy** (`include = ["tsai"]`): smoke fails with `ModuleNotFoundError: No module named 'tsai.data'`, exit 1.
- **Fixed** (`include = ["tsai", "tsai.*"]`): smoke prints `tsai 1.0.1: all subpackages and core modules present`, exit 0.

## Dependency

Branched off `fix/962-pypi-subpackages` (#963), so its diff temporarily shows that fix commit too. Once #963 merges, this branch can be rebased onto `main` and the diff will collapse to just the workflow change.

## Test plan

- [ ] CI runs both jobs (`test` and `verify-build`) on this PR; both pass.
- [ ] Confirm `verify-build` takes well under a minute (no heavy deps).
- [ ] After #963 merges and this is rebased, re-run CI on the rebased branch to confirm it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)