### PR TITLE
Make Reshape TorchScript-compatible

### DIFF
--- a/nbs/029_models.layers.ipynb
+++ b/nbs/029_models.layers.ipynb
@@ -903,7 +903,10 @@
     "class Reshape(Module):\n",
     "    def __init__(self, *shape): self.shape = shape\n",
     "    def forward(self, x):\n",
-    "        return x.contiguous().reshape(x.shape[0], -1) if not self.shape else x.contiguous().reshape(-1) if self.shape == (-1,) else x.contiguous().reshape(x.shape[0], *self.shape)\n",
+    "        x = x.contiguous()\n",
+    "        if len(self.shape) == 0: return x.reshape(x.shape[0], -1)\n",
+    "        elif self.shape == (-1,): return x.reshape(-1)\n",
+    "        else: return x.reshape(x.shape[0], *self.shape)\n",
     "    def __repr__(self): return f\"{self.__class__.__name__}({', '.join(['bs'] + [str(s) for s in self.shape])})\"\n",
     "\n",
     "\n",
@@ -995,6 +998,7 @@
     "test_eq(Reshape(-1, 2, 10)(t).shape, (bs, 1, 2, 10))\n",
     "test_eq(Reshape()(t).shape, (2, 20))\n",
     "test_eq(Reshape(-1)(t).shape, (40,))\n",
+    "test_eq(torch.jit.script(Reshape())(t).shape, (2, 20))\n",
     "Transpose(1,2), Permute(0,2,1), View(-1, 2, 10), Transpose(1,2, contiguous=True), Reshape(-1, 2, 10), Noop"
    ]
   },

--- a/tsai/models/layers.py
+++ b/tsai/models/layers.py
@@ -428,7 +428,10 @@ class View(Module):
 class Reshape(Module):
     def __init__(self, *shape): self.shape = shape
     def forward(self, x):
-        return x.contiguous().reshape(x.shape[0], -1) if not self.shape else x.contiguous().reshape(-1) if self.shape == (-1,) else x.contiguous().reshape(x.shape[0], *self.shape)
+        x = x.contiguous()
+        if len(self.shape) == 0: return x.reshape(x.shape[0], -1)
+        elif self.shape == (-1,): return x.reshape(-1)
+        else: return x.reshape(x.shape[0], *self.shape)
     def __repr__(self): return f"{self.__class__.__name__}({', '.join(['bs'] + [str(s) for s in self.shape])})"
 
 


### PR DESCRIPTION
## Summary
- Make `Reshape.forward` avoid tuple truthiness so TorchScript can compile the empty-shape path.
- Keep the existing reshape behavior for `Reshape()`, `Reshape(-1)`, and shaped reshapes.
- Add notebook regression coverage for scripting `Reshape()`.

## Test plan
- [x] reproduced the original failure with `torch.jit.script(Reshape())` before the fix
- [x] `PYTHONPATH=. .venv/bin/python - <<'PY' ... torch.jit.script(Reshape()) ... PY`
- [x] `nbdev-test --path nbs/029_models.layers.ipynb`
- [x] `nbdev-export`
- [x] `nbdev-clean`

Closes #950
