### PR TITLE
Avoid Adult Sample downloads in tabular tests

### DIFF
--- a/nbs/014_data.tabular.ipynb
+++ b/nbs/014_data.tabular.ipynb
@@ -142,6 +142,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7b9f2d64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "_test_df = pd.DataFrame({\n",
+    "    'workclass': ['Private', 'Self-emp', 'Private', 'Gov', 'Gov'],\n",
+    "    'education': ['HS', 'College', 'HS', 'PhD', 'College'],\n",
+    "    'age': [25, 45, 31, 52, 38],\n",
+    "    'hours-per-week': [40, 50, 35, 45, 42],\n",
+    "    'salary': ['<=50k', '>50k', '<=50k', '>50k', '<=50k'],\n",
+    "})\n",
+    "_test_cat_names = ['workclass', 'education']\n",
+    "_test_cont_names = ['age', 'hours-per-week']\n",
+    "_test_splits = ([0, 1, 2], [3, 4])\n",
+    "\n",
+    "_test_dls = get_tabular_dls(_test_df, cat_names=_test_cat_names, cont_names=_test_cont_names, y_names='salary',\n",
+    "                            splits=_test_splits, bs=2, device=device)\n",
+    "assert len(_test_dls.train_ds) == len(_test_splits[0])\n",
+    "assert len(_test_dls.valid_ds) == len(_test_splits[1])\n",
+    "\n",
+    "_test_processed_df, _test_procs = preprocess_df(_test_df, procs=[Categorify, FillMissing, Normalize], cat_names=_test_cat_names,\n",
+    "                                                cont_names=_test_cont_names, y_names='salary', reduce_memory=True)\n",
+    "assert _test_processed_df.shape[0] == len(_test_df)\n",
+    "assert set(_test_processed_df.columns) == set(_test_cat_names + _test_cont_names + ['salary'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "df85c61e",
    "metadata": {},
    "outputs": [
@@ -362,6 +392,7 @@
     }
    ],
    "source": [
+    "#|eval: false\n",
     "path = untar_data(URLs.ADULT_SAMPLE)\n",
     "df = pd.read_csv(path/'adult.csv')\n",
     "# df['salary'] = np.random.rand(len(df)) # uncomment to simulate a cont dependent variable\n",
@@ -442,6 +473,7 @@
     }
    ],
    "source": [
+    "#|eval: false\n",
     "metrics = mae if dls.c == 1 else accuracy\n",
     "learn = tabular_learner(dls, layers=[200, 100], y_range=None, metrics=metrics)\n",
     "learn.fit(1, 1e-2)"
@@ -990,6 +1022,7 @@
     }
    ],
    "source": [
+    "#|eval: false\n",
     "learn.dls.one_batch()"
    ]
   },
@@ -1041,6 +1074,7 @@
     }
    ],
    "source": [
+    "#|eval: false\n",
     "learn.model"
    ]
   },
@@ -1212,6 +1246,7 @@
     }
    ],
    "source": [
+    "#|eval: false\n",
     "path = untar_data(URLs.ADULT_SAMPLE)\n",
     "df = pd.read_csv(path/'adult.csv')\n",
     "cat_names = ['workclass', 'education', 'education-num', 'marital-status', 'occupation', 'relationship', 'race', 'sex',\n",
@@ -1257,6 +1292,7 @@
     }
    ],
    "source": [
+    "#|eval: false\n",
     "procs.classes, procs.means, procs.stds"
    ]
   },


### PR DESCRIPTION
## Summary
- add a small hidden synthetic-data regression cell for `get_tabular_dls` and `preprocess_df`
- mark the Adult Sample demo/training cells as non-evaluated during notebook tests
- remove the default CI dependency on downloading `URLs.ADULT_SAMPLE` from `nbs/014_data.tabular.ipynb`

## Test plan
- [x] `nbdev-test --path nbs/014_data.tabular.ipynb`
- [x] `nbdev-export`
- [x] `nbdev-clean`
- [ ] GitHub Actions full nbdev suite

Closes #977
