### PR TITLE
Avoid NATOPS download in external data tests

### DIFF
--- a/nbs/005_data.external.ipynb
+++ b/nbs/005_data.external.ipynb
@@ -2427,10 +2427,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "343fe2ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "_dsid = 'AtrialFibrillation'\n",
+    "_X_train, _y_train, _X_valid, _y_valid = get_UCR_data(_dsid)\n",
+    "_X, _y, _splits = get_UCR_data(_dsid, split_data=False)\n",
+    "test_eq(_X[_splits[0]], _X_train)\n",
+    "test_eq(_y[_splits[1]], _y_valid)\n",
+    "test_type(_X, _X_train)\n",
+    "test_type(_y, _y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "71520764",
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|eval: false\n",
     "X_train, y_train, X_valid, y_valid = get_UCR_data('natops')"
    ]
   },
@@ -2454,6 +2472,7 @@
     }
    ],
    "source": [
+    "#|eval: false\n",
     "dsid = 'natops'\n",
     "X_train, y_train, X_valid, y_valid = get_UCR_data(dsid, verbose=True)\n",
     "X, y, splits = get_UCR_data(dsid, split_data=False)\n",


### PR DESCRIPTION
## Summary
- add a hidden split-data regression that reuses the already-tested `AtrialFibrillation` UCR dataset
- mark the NATOPS demo cells as non-evaluated during notebook tests
- remove an extra default CI dependency on downloading/parsing the NATOPS archive

## Test plan
- [x] `nbdev-test --path nbs/005_data.external.ipynb`
- [x] `nbdev-export`
- [x] `nbdev-clean`
- [ ] GitHub Actions full nbdev suite

Closes #979
