### PR TITLE
Add MiniRocket PyTorch docstrings

### DIFF
--- a/nbs/056_models.MINIROCKET_Pytorch.ipynb
+++ b/nbs/056_models.MINIROCKET_Pytorch.ipynb
@@ -228,6 +228,7 @@
    "source": [
     "#|export\n",
     "class MiniRocketHead(nn.Sequential):\n",
+    "    \"\"\"Classification/regression head for MiniRocket features.\"\"\"\n",
     "    def __init__(self, c_in, c_out, seq_len=1, bn=True, fc_dropout=0.):\n",
     "        layers = [nn.Flatten()]\n",
     "        if bn:\n",
@@ -252,6 +253,7 @@
    "source": [
     "#|export\n",
     "class MiniRocket(nn.Sequential):\n",
+    "    \"\"\"PyTorch MiniRocket model with online feature extraction and a linear head.\"\"\"\n",
     "    def __init__(self, c_in, c_out, seq_len, num_features=10_000, max_dilations_per_kernel=32, random_state=None, bn=True, fc_dropout=0):\n",
     "        \n",
     "        # Backbone\n",

--- a/tsai/models/MINIROCKET_Pytorch.py
+++ b/tsai/models/MINIROCKET_Pytorch.py
@@ -168,6 +168,7 @@ def get_minirocket_features(o, model, chunksize=1024, use_cuda=None, to_np=True)
 
 # %% ../../nbs/056_models.MINIROCKET_Pytorch.ipynb #ed23946b
 class MiniRocketHead(nn.Sequential):
+    """Classification/regression head for MiniRocket features."""
     def __init__(self, c_in, c_out, seq_len=1, bn=True, fc_dropout=0.):
         layers = [nn.Flatten()]
         if bn:
@@ -184,6 +185,7 @@ class MiniRocketHead(nn.Sequential):
 
 # %% ../../nbs/056_models.MINIROCKET_Pytorch.ipynb #08a478a3
 class MiniRocket(nn.Sequential):
+    """PyTorch MiniRocket model with online feature extraction and a linear head."""
     def __init__(self, c_in, c_out, seq_len, num_features=10_000, max_dilations_per_kernel=32, random_state=None, bn=True, fc_dropout=0):
         
         # Backbone


### PR DESCRIPTION
## Summary
- add explicit docstrings for the PyTorch `MiniRocket` and `MiniRocketHead` classes
- prevent nbdev docs from falling back to inherited `nn.Sequential` documentation for MiniRocket
- keep implementation behavior unchanged

## Test plan
- [x] `nbdev-export`
- [x] `nbdev-test --path nbs/056_models.MINIROCKET_Pytorch.ipynb`
- [x] `inspect.getdoc(MiniRocket)` returns MiniRocket-specific documentation

Closes #957
